### PR TITLE
Properly merges enums on schema flattening

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lockedon/lovii-schema "0.2.11"
+(defproject lockedon/lovii-schema "0.2.12"
   :description "Describe your application schema using data."
   :url "https://github.com/LockedOn/lovii-schema"
   :license {:name "MIT"

--- a/src/lovii_schema/util.clj
+++ b/src/lovii_schema/util.clj
@@ -15,12 +15,17 @@
                         {:schema1 s1cmp
                          :schema2 s2cmp}))))))
 
+(defn combine [vs1 vs2]
+  (assert (or (and (sequential? vs1) (sequential? vs2))
+              (and (map? vs1) (map? vs2))))
+  (into vs1 vs2))
+
 (defn merge-schemas [m1 m2]
   (assert-schemas-compatible m1 m2)
   (cond-> (merge m1 m2)
     (or (= :enum (:type m1))
         (= :enum (:enum m2)))
-    (assoc :values (into (vec (:values m1)) (:values m2)))))
+    (update :values combine (:values m1))))
 
 (defn no-enum-values-also-variants [flat-schema]
   (let [values-enums (->> (dissoc flat-schema :schema/variant)

--- a/src/lovii_schema/util.clj
+++ b/src/lovii_schema/util.clj
@@ -6,22 +6,50 @@
             (conj res (-> m :schema/variant :variant)))
           [] schema))
 
+(defn assert-schemas-compatible [s1 s2]
+  (let [compare-keys [:type :index :cardinality]]
+    (let [s1cmp (select-keys s1 compare-keys)
+          s2cmp (select-keys s2 compare-keys)]
+      (when (and s1 s2 (not= s1cmp s2cmp))
+        (throw (ex-info "Variant schemas differ in an incompatible way"
+                        {:schema1 s1cmp
+                         :schema2 s2cmp}))))))
+
+(defn merge-schemas [m1 m2]
+  (assert-schemas-compatible m1 m2)
+  (cond-> (merge m1 m2)
+    (or (= :enum (:type m1))
+        (= :enum (:enum m2)))
+    (assoc :values (into (vec (:values m1)) (:values m2)))))
+
+(defn no-enum-values-also-variants [flat-schema]
+  (let [values-enums (->> (dissoc flat-schema :schema/variant)
+                          (keep (comp :values val))
+                          (reduce into [])
+                          (map first)
+                          (set))
+        variants-enums (set (keys (:values (:schema/variant flat-schema))))
+        intersection (clojure.set/intersection values-enums variants-enums)]
+    (empty? intersection)))
+
+(defn flatten-schema-unmemoized [schema]
+  {:post [(no-enum-values-also-variants %)]}
+  (->> schema
+       (reduce (fn [res m]
+                 (-> m
+                     (dissoc :schema/variant)
+                     (dissoc :schema/abstract)
+                     (->> (merge-with merge-schemas res))))
+               {})
+       (merge {:schema/variant {:type :enum
+                                :cardinality :one
+                                :values (reduce (fn [res ke]
+                                                  (assoc res ke (str ke)))
+                                                {}
+                                                (all-variants schema))}})))
 (def flatten-schema
-  (memoize
-   (fn [schema]
-     (->> schema
-          (reduce (fn [res m]
-                    (-> m
-                        (dissoc :schema/variant)
-                        (dissoc :schema/abstract)
-                        (->> (merge res))))
-                  {})
-          (merge {:schema/variant {:type :enum
-                                   :cardinality :one
-                                   :values (reduce (fn [res ke]
-                                                     (assoc res ke (str ke)))
-                                                   {}
-                                                   (all-variants schema))}})))))
+  (memoize flatten-schema-unmemoized))
+
 (defn get-abstract
   [variant]
   (when (keyword? variant)


### PR DESCRIPTION
Asserts that schemas are compatible when flattening, and that no variant
enums conflict with value enums

Note that extra variant enum assertion will cause schema loading to fail in existing code, and will need to be fixed. Feel free to disable the post condition if necessary.