### PR TITLE
Detect collisions between schema attributes and variants

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lockedon/lovii-schema "0.2.14"
+(defproject lockedon/lovii-schema "0.2.15"
   :description "Describe your application schema using data."
   :url "https://github.com/LockedOn/lovii-schema"
   :license {:name "MIT"


### PR DESCRIPTION
I also made the other variant/enums check explicitly throw an exception. This way it can provide more information about which enums/variants collide.
